### PR TITLE
Cleanup UI

### DIFF
--- a/Client/WindowClient.cs
+++ b/Client/WindowClient.cs
@@ -176,8 +176,7 @@ namespace Client
                     ClientDisconnected();
                     return;
                 }
-
-                if (videostreamToken.Token.IsCancellationRequested)
+                catch (OperationCanceledException)
                 {
                     ClientDisconnected();
                     return;
@@ -251,9 +250,14 @@ namespace Client
                 }
 
                 string[] metapacket = Encoding.UTF8.GetString(packet).TrimEnd('\0').Split(Constants.ParameterSeparator);
-                var packetType = (ServerPacketHeader)int.Parse(metapacket[0]);
 
-                switch (packetType)
+                if (!int.TryParse(metapacket[0], out int packetTypeValue))
+                {
+                    Log.Debug($"Received invalid packet[0]: {metapacket[0]}");
+                    continue;
+                }
+
+                switch ((ServerPacketHeader)packetTypeValue)
                 {
                     case ServerPacketHeader.ConnectionReply:
                         if (Parse.TryParseConnectionReply(metapacket, out bool accepted, out Size resolution, out int videoPort))

--- a/Client/WindowDisplay.Designer.cs
+++ b/Client/WindowDisplay.Designer.cs
@@ -38,6 +38,7 @@
             this.statusStripFooter = new System.Windows.Forms.StatusStrip();
             this.toolStripStatusLabelLatest = new System.Windows.Forms.ToolStripStatusLabel();
             this.displayArea = new System.Windows.Forms.PictureBox();
+            this.toolStripStatusLabelResolution = new System.Windows.Forms.ToolStripStatusLabel();
             this.toolStripHeader.SuspendLayout();
             this.statusStripFooter.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.displayArea)).BeginInit();
@@ -109,6 +110,7 @@
             // 
             this.statusStripFooter.ImageScalingSize = new System.Drawing.Size(20, 20);
             this.statusStripFooter.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripStatusLabelResolution,
             this.toolStripStatusLabelLatest});
             this.statusStripFooter.Location = new System.Drawing.Point(0, 279);
             this.statusStripFooter.Name = "statusStripFooter";
@@ -132,6 +134,12 @@
             this.displayArea.Size = new System.Drawing.Size(448, 254);
             this.displayArea.TabIndex = 2;
             this.displayArea.TabStop = false;
+            // 
+            // toolStripStatusLabelResolution
+            // 
+            this.toolStripStatusLabelResolution.Name = "toolStripStatusLabelResolution";
+            this.toolStripStatusLabelResolution.Size = new System.Drawing.Size(168, 17);
+            this.toolStripStatusLabelResolution.Text = "toolStripStatusLabelResolution";
             // 
             // WindowDisplay
             // 
@@ -169,6 +177,7 @@
         private System.Windows.Forms.ToolStripButton toolStripButtonConnect;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
         private System.Windows.Forms.ToolStripButton toolStripButtonOptions;
+        private System.Windows.Forms.ToolStripStatusLabel toolStripStatusLabelResolution;
     }
 }
 

--- a/Client/WindowDisplay.Designer.cs
+++ b/Client/WindowDisplay.Designer.cs
@@ -91,15 +91,18 @@
             // 
             this.toolStripSeparator2.Name = "toolStripSeparator2";
             this.toolStripSeparator2.Size = new System.Drawing.Size(6, 25);
+            this.toolStripSeparator2.Visible = false;
             // 
             // toolStripButtonOptions
             // 
             this.toolStripButtonOptions.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.toolStripButtonOptions.Enabled = false;
             this.toolStripButtonOptions.Image = ((System.Drawing.Image)(resources.GetObject("toolStripButtonOptions.Image")));
             this.toolStripButtonOptions.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.toolStripButtonOptions.Name = "toolStripButtonOptions";
             this.toolStripButtonOptions.Size = new System.Drawing.Size(53, 22);
             this.toolStripButtonOptions.Text = "&Options";
+            this.toolStripButtonOptions.Visible = false;
             this.toolStripButtonOptions.Click += new System.EventHandler(this.toolStripButtonOptions_Click);
             // 
             // statusStripFooter

--- a/Client/WindowDisplay.cs
+++ b/Client/WindowDisplay.cs
@@ -33,6 +33,11 @@ namespace Client
         {
             formToPanelSize = Size.Subtract(Size, displayArea.Size);
 
+            // Update UI
+            ResizeToFit();
+            ToggleDragableBorder(!toolStripButtonResizeToFit.Checked);
+            toolStripStatusLabelResolution.Text = string.Empty;
+
             await HandleCommandlineArgumentsAsync(Environment.GetCommandLineArgs());
         }
 
@@ -131,6 +136,7 @@ namespace Client
                 Invoke((MethodInvoker)delegate
                 {
                     ResizeToFit();
+                    toolStripStatusLabelResolution.Text = $"{videoResolution.Width}x{videoResolution.Height}";
                 });
             }
         }
@@ -142,13 +148,29 @@ namespace Client
             if (toolStripButtonResizeToFit.Checked)
             {
                 ResizeToFit();
-                FormBorderStyle = FormBorderStyle.FixedSingle;
-                statusStripFooter.SizingGrip = false;
             }
-            else
+
+            ToggleDragableBorder(!toolStripButtonResizeToFit.Checked);
+        }
+
+        void ToggleDragableBorder(bool dragable)
+        {
+            if (dragable)
             {
                 FormBorderStyle = FormBorderStyle.Sizable;
                 statusStripFooter.SizingGrip = true;
+                MaximizeBox = true;
+            }
+            else
+            {
+                FormBorderStyle = FormBorderStyle.FixedSingle;
+                statusStripFooter.SizingGrip = false;
+                MaximizeBox = false;
+
+                if (WindowState == FormWindowState.Maximized)
+                {
+                    WindowState = FormWindowState.Normal;
+                }
             }
         }
 

--- a/Server/WindowCapture.Designer.cs
+++ b/Server/WindowCapture.Designer.cs
@@ -38,12 +38,10 @@
             this.toolStripTextBoxAcceptableHost = new System.Windows.Forms.ToolStripTextBox();
             this.toolStripLabel1 = new System.Windows.Forms.ToolStripLabel();
             this.toolStripTextBoxTargetPort = new System.Windows.Forms.ToolStripTextBox();
-            this.toolStripButtonConnect = new System.Windows.Forms.ToolStripButton();
+            this.toolStripButtonActionStop = new System.Windows.Forms.ToolStripButton();
+            this.toolStripButtonActionStart = new System.Windows.Forms.ToolStripButton();
             this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
             this.toolStripButtonOptions = new System.Windows.Forms.ToolStripButton();
-            this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-            this.toolStripButtonApplicationSelector = new System.Windows.Forms.ToolStripButton();
-            this.toolStripButtonDebug1 = new System.Windows.Forms.ToolStripButton();
             this.captureArea = new System.Windows.Forms.Panel();
             this.toolTipMain = new System.Windows.Forms.ToolTip(this.components);
             this.statusStripFooter.SuspendLayout();
@@ -91,94 +89,78 @@
             this.toolStripTextBoxAcceptableHost,
             this.toolStripLabel1,
             this.toolStripTextBoxTargetPort,
-            this.toolStripButtonConnect,
+            this.toolStripButtonActionStop,
+            this.toolStripButtonActionStart,
             this.toolStripSeparator2,
-            this.toolStripButtonOptions,
-            this.toolStripSeparator1,
-            this.toolStripButtonApplicationSelector,
-            this.toolStripButtonDebug1});
+            this.toolStripButtonOptions});
             this.toolStripHeader.Location = new System.Drawing.Point(0, 0);
             this.toolStripHeader.Name = "toolStripHeader";
             this.toolStripHeader.RenderMode = System.Windows.Forms.ToolStripRenderMode.Professional;
-            this.toolStripHeader.Size = new System.Drawing.Size(509, 27);
+            this.toolStripHeader.Size = new System.Drawing.Size(509, 25);
             this.toolStripHeader.TabIndex = 1;
             this.toolStripHeader.Text = "toolStrip1";
             // 
             // toolStripTextBoxAcceptableHost
             // 
             this.toolStripTextBoxAcceptableHost.Name = "toolStripTextBoxAcceptableHost";
-            this.toolStripTextBoxAcceptableHost.Size = new System.Drawing.Size(106, 27);
+            this.toolStripTextBoxAcceptableHost.Size = new System.Drawing.Size(106, 25);
             this.toolStripTextBoxAcceptableHost.ToolTipText = "IP to accept connection from, leave blank for any";
             // 
             // toolStripLabel1
             // 
             this.toolStripLabel1.Name = "toolStripLabel1";
-            this.toolStripLabel1.Size = new System.Drawing.Size(10, 24);
+            this.toolStripLabel1.Size = new System.Drawing.Size(10, 22);
             this.toolStripLabel1.Text = ":";
             // 
             // toolStripTextBoxTargetPort
             // 
             this.toolStripTextBoxTargetPort.MaxLength = 5;
             this.toolStripTextBoxTargetPort.Name = "toolStripTextBoxTargetPort";
-            this.toolStripTextBoxTargetPort.ReadOnly = true;
-            this.toolStripTextBoxTargetPort.Size = new System.Drawing.Size(53, 27);
+            this.toolStripTextBoxTargetPort.Size = new System.Drawing.Size(53, 25);
             // 
-            // toolStripButtonConnect
+            // toolStripButtonActionStop
             // 
-            this.toolStripButtonConnect.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.toolStripButtonConnect.Image = ((System.Drawing.Image)(resources.GetObject("toolStripButtonConnect.Image")));
-            this.toolStripButtonConnect.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.toolStripButtonConnect.Name = "toolStripButtonConnect";
-            this.toolStripButtonConnect.Size = new System.Drawing.Size(35, 24);
-            this.toolStripButtonConnect.Text = "&Start";
-            this.toolStripButtonConnect.Click += new System.EventHandler(this.toolStripButtonConnect_ClickAsync);
+            this.toolStripButtonActionStop.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.toolStripButtonActionStop.Image = ((System.Drawing.Image)(resources.GetObject("toolStripButtonActionStop.Image")));
+            this.toolStripButtonActionStop.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.toolStripButtonActionStop.Name = "toolStripButtonActionStop";
+            this.toolStripButtonActionStop.Size = new System.Drawing.Size(35, 22);
+            this.toolStripButtonActionStop.Text = "&Stop";
+            this.toolStripButtonActionStop.Click += new System.EventHandler(this.toolStripButtonActionStop_Click);
+            // 
+            // toolStripButtonActionStart
+            // 
+            this.toolStripButtonActionStart.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.toolStripButtonActionStart.Image = ((System.Drawing.Image)(resources.GetObject("toolStripButtonActionStart.Image")));
+            this.toolStripButtonActionStart.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.toolStripButtonActionStart.Name = "toolStripButtonActionStart";
+            this.toolStripButtonActionStart.Size = new System.Drawing.Size(35, 22);
+            this.toolStripButtonActionStart.Text = "&Start";
+            this.toolStripButtonActionStart.Click += new System.EventHandler(this.toolStripButtonActionStart_ClickAsync);
             // 
             // toolStripSeparator2
             // 
             this.toolStripSeparator2.Name = "toolStripSeparator2";
-            this.toolStripSeparator2.Size = new System.Drawing.Size(6, 27);
+            this.toolStripSeparator2.Size = new System.Drawing.Size(6, 25);
             // 
             // toolStripButtonOptions
             // 
             this.toolStripButtonOptions.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.toolStripButtonOptions.Enabled = false;
             this.toolStripButtonOptions.Image = ((System.Drawing.Image)(resources.GetObject("toolStripButtonOptions.Image")));
             this.toolStripButtonOptions.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.toolStripButtonOptions.Name = "toolStripButtonOptions";
-            this.toolStripButtonOptions.Size = new System.Drawing.Size(53, 24);
+            this.toolStripButtonOptions.Size = new System.Drawing.Size(53, 22);
             this.toolStripButtonOptions.Text = "&Options";
+            this.toolStripButtonOptions.Visible = false;
             this.toolStripButtonOptions.Click += new System.EventHandler(this.toolStripButtonOptions_Click);
-            // 
-            // toolStripSeparator1
-            // 
-            this.toolStripSeparator1.Name = "toolStripSeparator1";
-            this.toolStripSeparator1.Size = new System.Drawing.Size(6, 27);
-            // 
-            // toolStripButtonApplicationSelector
-            // 
-            this.toolStripButtonApplicationSelector.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStripButtonApplicationSelector.Image = ((System.Drawing.Image)(resources.GetObject("toolStripButtonApplicationSelector.Image")));
-            this.toolStripButtonApplicationSelector.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.toolStripButtonApplicationSelector.Name = "toolStripButtonApplicationSelector";
-            this.toolStripButtonApplicationSelector.Size = new System.Drawing.Size(24, 24);
-            this.toolStripButtonApplicationSelector.Text = "toolStripButtonApplicationSelector";
-            this.toolStripButtonApplicationSelector.Click += new System.EventHandler(this.toolStripButtonApplicationSelector_Click);
-            // 
-            // toolStripButtonDebug1
-            // 
-            this.toolStripButtonDebug1.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStripButtonDebug1.Image = ((System.Drawing.Image)(resources.GetObject("toolStripButtonDebug1.Image")));
-            this.toolStripButtonDebug1.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.toolStripButtonDebug1.Name = "toolStripButtonDebug1";
-            this.toolStripButtonDebug1.Size = new System.Drawing.Size(24, 24);
-            this.toolStripButtonDebug1.Text = "Debug1";
-            this.toolStripButtonDebug1.Click += new System.EventHandler(this.toolStripButtonDebug1_Click);
             // 
             // captureArea
             // 
             this.captureArea.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.captureArea.Location = new System.Drawing.Point(0, 27);
+            this.captureArea.Location = new System.Drawing.Point(0, 25);
             this.captureArea.Name = "captureArea";
-            this.captureArea.Size = new System.Drawing.Size(509, 282);
+            this.captureArea.Size = new System.Drawing.Size(509, 284);
             this.captureArea.TabIndex = 2;
             // 
             // WindowCapture
@@ -212,15 +194,13 @@
         private System.Windows.Forms.ToolStripStatusLabel toolStripStatusLabelResolution;
         private System.Windows.Forms.Panel captureArea;
         private System.Windows.Forms.ToolStripTextBox toolStripTextBoxAcceptableHost;
-        private System.Windows.Forms.ToolStripButton toolStripButtonConnect;
+        private System.Windows.Forms.ToolStripButton toolStripButtonActionStart;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
         private System.Windows.Forms.ToolStripButton toolStripButtonOptions;
         private System.Windows.Forms.ToolStripLabel toolStripLabel1;
         private System.Windows.Forms.ToolStripTextBox toolStripTextBoxTargetPort;
-        private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
         private System.Windows.Forms.ToolTip toolTipMain;
-        private System.Windows.Forms.ToolStripButton toolStripButtonApplicationSelector;
-        private System.Windows.Forms.ToolStripButton toolStripButtonDebug1;
+        private System.Windows.Forms.ToolStripButton toolStripButtonActionStop;
     }
 }
 

--- a/Server/WindowCapture.cs
+++ b/Server/WindowCapture.cs
@@ -73,6 +73,9 @@ namespace Server
             UpdateResolutionVariables();
             toolStripTextBoxTargetPort.Text = DefaultMetastreamPort.ToString();
 
+            // Update UI
+            ToggleActionStartStopButtons(false);
+
             // Handle command-line arguments
             await HandleCommandlineArgumentsAsync(Environment.GetCommandLineArgs());
         }
@@ -258,8 +261,7 @@ namespace Server
                 //captureAreaTopLeft = captureArea.Bounds.Location;
             }
 
-            toolStripStatusLabelResolution.Text = videoResolution.Width.ToString() + "x" + videoResolution.Height.ToString();
-
+            toolStripStatusLabelResolution.Text = $"{videoResolution.Width}x{videoResolution.Height}";
             server?.UpdateResolution(videoResolution);
         }
 

--- a/Server/WindowCapture.cs
+++ b/Server/WindowCapture.cs
@@ -13,7 +13,7 @@ namespace Server
     public partial class WindowCapture : Form
     {
         static readonly int DefaultMetastreamPort = 10063;
-        readonly Color transparencyKeyColor = Color.Orange;
+        static readonly Color transparencyKeyColor = Color.Orange;
 
         bool fullscreen;
         Size videoResolution;
@@ -195,7 +195,8 @@ namespace Server
 
         void toolStripButtonActionStop_Click(object sender, EventArgs e)
         {
-            server.Dispose();
+            server?.Dispose();
+            server = null;
             ToggleActionStartStopButtons(false);
 
             Log.Information("Stopped server");

--- a/Server/WindowCapture.resx
+++ b/Server/WindowCapture.resx
@@ -64,7 +64,22 @@
     <value>200, 20</value>
   </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="toolStripButtonConnect.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="toolStripButtonActionStop.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAIDSURBVDhPpZLrS5NhGMb3j4SWh0oRQVExD4gonkDpg4hG
+        YKxG6WBogkMZKgPNCEVJFBGdGETEvgwyO9DJE5syZw3PIlPEE9pgBCLZ5XvdMB8Ew8gXbl54nuf63dd9
+        0OGSnwCahxbPRNPAPMw9Xpg6ZmF46kZZ0xSKzJPIrhpDWsVnpBhGkKx3nAX8Pv7z1zg8OoY/cITdn4fw
+        bf/C0kYAN3Ma/w3gWfZL5kzTKBxjWyK2DftwI9tyMYCZKXbNHaD91bLYJrDXsYbrWfUKwJrPE9M2M1Oc
+        VzOOpHI7Jr376Hi9ogHqFIANO0/MmmmbmSmm9a8ze+I4MrNWAdjtoJgWcx+PSzg166yZZ8xM8XvXDix9
+        c4jIqFYAjoriBV9AhEPv1mH/sonogha0afbZMMZz+yreTGyhpusHwtNNCsA5U1zS4BLxzJIfg299qO32
+        Ir7UJtZfftyATqeT+8o2D8JSjQrAJblrncYL7ZJ2+bfaFnC/1S1NjL3diRat7qrO7wLRP3HjWsojBeCo
+        mDEo5mNjuweFGvjWg2EBhCbpkW78htSHHwRyNdmgAFzPEee2iFkzayy2OLXzT4gr6UdUnlXrullsxxQ+
+        kx0g8BTA3aZlButjSTyjODq/WcQcW/B/Je4OQhLvKQDnzN1mp0nnkvAhR8VuMzNrpm1mpjgkoVwB/v8D
+        TgDQASA1MVpwzwAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="toolStripButtonActionStart.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
         YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAIDSURBVDhPpZLrS5NhGMb3j4SWh0oRQVExD4gonkDpg4hG
@@ -80,36 +95,6 @@
 </value>
   </data>
   <data name="toolStripButtonOptions.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAIDSURBVDhPpZLrS5NhGMb3j4SWh0oRQVExD4gonkDpg4hG
-        YKxG6WBogkMZKgPNCEVJFBGdGETEvgwyO9DJE5syZw3PIlPEE9pgBCLZ5XvdMB8Ew8gXbl54nuf63dd9
-        0OGSnwCahxbPRNPAPMw9Xpg6ZmF46kZZ0xSKzJPIrhpDWsVnpBhGkKx3nAX8Pv7z1zg8OoY/cITdn4fw
-        bf/C0kYAN3Ma/w3gWfZL5kzTKBxjWyK2DftwI9tyMYCZKXbNHaD91bLYJrDXsYbrWfUKwJrPE9M2M1Oc
-        VzOOpHI7Jr376Hi9ogHqFIANO0/MmmmbmSmm9a8ze+I4MrNWAdjtoJgWcx+PSzg166yZZ8xM8XvXDix9
-        c4jIqFYAjoriBV9AhEPv1mH/sonogha0afbZMMZz+yreTGyhpusHwtNNCsA5U1zS4BLxzJIfg299qO32
-        Ir7UJtZfftyATqeT+8o2D8JSjQrAJblrncYL7ZJ2+bfaFnC/1S1NjL3diRat7qrO7wLRP3HjWsojBeCo
-        mDEo5mNjuweFGvjWg2EBhCbpkW78htSHHwRyNdmgAFzPEee2iFkzayy2OLXzT4gr6UdUnlXrullsxxQ+
-        kx0g8BTA3aZlButjSTyjODq/WcQcW/B/Je4OQhLvKQDnzN1mp0nnkvAhR8VuMzNrpm1mpjgkoVwB/v8D
-        TgDQASA1MVpwzwAAAABJRU5ErkJggg==
-</value>
-  </data>
-  <data name="toolStripButtonApplicationSelector.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAIDSURBVDhPpZLrS5NhGMb3j4SWh0oRQVExD4gonkDpg4hG
-        YKxG6WBogkMZKgPNCEVJFBGdGETEvgwyO9DJE5syZw3PIlPEE9pgBCLZ5XvdMB8Ew8gXbl54nuf63dd9
-        0OGSnwCahxbPRNPAPMw9Xpg6ZmF46kZZ0xSKzJPIrhpDWsVnpBhGkKx3nAX8Pv7z1zg8OoY/cITdn4fw
-        bf/C0kYAN3Ma/w3gWfZL5kzTKBxjWyK2DftwI9tyMYCZKXbNHaD91bLYJrDXsYbrWfUKwJrPE9M2M1Oc
-        VzOOpHI7Jr376Hi9ogHqFIANO0/MmmmbmSmm9a8ze+I4MrNWAdjtoJgWcx+PSzg166yZZ8xM8XvXDix9
-        c4jIqFYAjoriBV9AhEPv1mH/sonogha0afbZMMZz+yreTGyhpusHwtNNCsA5U1zS4BLxzJIfg299qO32
-        Ir7UJtZfftyATqeT+8o2D8JSjQrAJblrncYL7ZJ2+bfaFnC/1S1NjL3diRat7qrO7wLRP3HjWsojBeCo
-        mDEo5mNjuweFGvjWg2EBhCbpkW78htSHHwRyNdmgAFzPEee2iFkzayy2OLXzT4gr6UdUnlXrullsxxQ+
-        kx0g8BTA3aZlButjSTyjODq/WcQcW/B/Je4OQhLvKQDnzN1mp0nnkvAhR8VuMzNrpm1mpjgkoVwB/v8D
-        TgDQASA1MVpwzwAAAABJRU5ErkJggg==
-</value>
-  </data>
-  <data name="toolStripButtonDebug1.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
         YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAIDSURBVDhPpZLrS5NhGMb3j4SWh0oRQVExD4gonkDpg4hG


### PR DESCRIPTION
- Disabled settings buttons for both server and client, as neither has any valid options.
- Disabled Application dropper-button on server as it hasn't been implemented, and isn't planned for [this milestone](https://github.com/kres0345/WindowStreamer/milestone/1).
- Added a stop button on server.