### PR TITLE
Separate Windows dependencies into separate assemblies

### DIFF
--- a/ClientApp/ClientApp.csproj
+++ b/ClientApp/ClientApp.csproj
@@ -22,6 +22,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Serilog" Version="3.0.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
@@ -36,6 +37,7 @@
   <ItemGroup>
     <ProjectReference Include="..\CommonApp\CommonApp.csproj" />
     <ProjectReference Include="..\WindowStreamer.Client\WindowStreamer.Client.csproj" />
+    <ProjectReference Include="..\WindowStreamer.Image.Windows\WindowStreamer.Image.Windows.csproj" />
     <ProjectReference Include="..\WindowStreamer.Protocol\WindowStreamer.Protocol.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/ServerApp/GetCaptureAreaFromControls.cs
+++ b/ServerApp/GetCaptureAreaFromControls.cs
@@ -1,15 +1,21 @@
-﻿using System.Drawing;
-using System.Windows.Forms;
+﻿using System.Windows.Forms;
+using WindowStreamer.Image;
 using WindowStreamer.Server;
 
 namespace ServerApp;
 
-internal class GetCaptureAreaFromControls : IGetCaptureArea
+public class GetCaptureAreaFromControls : IGetCaptureArea
 {
     readonly Control mainForm;
     readonly Control captureAreaPanel;
     readonly Control toolstripHeader;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GetCaptureAreaFromControls"/> class.
+    /// </summary>
+    /// <param name="mainForm">The main window of the application.</param>
+    /// <param name="captureAreaPanel">The panel denoting the capture area.</param>
+    /// <param name="toolstripHeader">The footer control.</param>
     public GetCaptureAreaFromControls(Control mainForm, Control captureAreaPanel, Control toolstripHeader)
     {
         this.mainForm = mainForm;
@@ -19,5 +25,5 @@ internal class GetCaptureAreaFromControls : IGetCaptureArea
 
     public Point Location => new Point(captureAreaPanel.Location.X + mainForm.Location.X, captureAreaPanel.Location.Y + mainForm.Location.Y + toolstripHeader.Height);
 
-    public Size Size => captureAreaPanel.Size;
+    public Size Size => new Size(captureAreaPanel.Size.Width, captureAreaPanel.Size.Height);
 }

--- a/ServerApp/ScreenshotGrabber.cs
+++ b/ServerApp/ScreenshotGrabber.cs
@@ -1,6 +1,8 @@
 ﻿using System.Drawing;
 using System.Drawing.Imaging;
 using System.Runtime.Versioning;
+using WindowStreamer.Image;
+using WindowStreamer.Image.Windows;
 using WindowStreamer.Server;
 
 namespace ServerApp;
@@ -14,7 +16,7 @@ internal class ScreenshotGrabber : IScreenshotQuery
     static readonly Brush UACPromptFillColor = Brushes.Turquoise;
 
     /// <inheritdoc/>
-    public Bitmap GetImage(Rectangle captureRect)
+    public IImage GetImage(WindowStreamer.Image.Point location, WindowStreamer.Image.Size captureRect)
     {
         var bmp = new Bitmap(captureRect.Width, captureRect.Height, PixelFormat.Format24bppRgb);
 
@@ -22,13 +24,13 @@ internal class ScreenshotGrabber : IScreenshotQuery
         try
         {
             // Exception happens during UAC prompts.
-            g.CopyFromScreen(captureRect.Left, captureRect.Top, 0, 0, bmp.Size, CopyPixelOperation.SourceCopy);
+            g.CopyFromScreen(location.X, location.Y, 0, 0, bmp.Size, CopyPixelOperation.SourceCopy);
         }
         catch (System.ComponentModel.Win32Exception)
         {
-            g.FillRectangle(UACPromptFillColor, captureRect);
+            g.FillRectangle(UACPromptFillColor, location.X, location.Y, captureRect.Width, captureRect.Height);
         }
 
-        return bmp;
+        return new NativeImage(bmp);
     }
 }

--- a/ServerApp/ServerApp.csproj
+++ b/ServerApp/ServerApp.csproj
@@ -47,7 +47,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Serilog" Version="3.0.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />

--- a/ServerApp/ServerApp.csproj
+++ b/ServerApp/ServerApp.csproj
@@ -71,6 +71,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CommonApp\CommonApp.csproj" />
+    <ProjectReference Include="..\WindowStreamer.Image.Windows\WindowStreamer.Image.Windows.csproj" />
     <ProjectReference Include="..\WindowStreamer.Protocol\WindowStreamer.Protocol.csproj" />
     <ProjectReference Include="..\WindowStreamer.Server\WindowStreamer.Server.csproj" />
   </ItemGroup>

--- a/ServerApp/WindowCapture.cs
+++ b/ServerApp/WindowCapture.cs
@@ -63,7 +63,7 @@ public partial class WindowCapture : Form
             else if (m.WParam == new IntPtr(0xF120))
             {
                 fullscreen = false;
-                Size = lastResolution;
+                Size = new Size(lastResolution.Width, lastResolution.Height);
                 UpdateResolutionVariables();
             }
         }
@@ -193,7 +193,7 @@ public partial class WindowCapture : Form
         server = new WindowServer(
             bindAddress,
             port,
-            videoResolution,
+            new WindowStreamer.Image.Size(videoResolution.Width, videoResolution.Height),
             serviceProvider.GetRequiredService<IScreenshotQuery>(),
             serviceProvider.GetRequiredService<IConnectionHandler>(),
             serviceProvider.GetRequiredService<IGetCaptureArea>());
@@ -221,17 +221,15 @@ public partial class WindowCapture : Form
     {
         if (fullscreen)
         {
-            videoResolution.Height = Screen.FromControl(this).Bounds.Height;
-            videoResolution.Width = Screen.FromControl(this).Bounds.Width;
+            videoResolution = Screen.FromControl(this).Bounds.Size;
         }
         else
         {
-            videoResolution.Height = captureArea.Height;
-            videoResolution.Width = captureArea.Width;
+            videoResolution = new Size(captureArea.Width, captureArea.Height);
         }
 
         toolStripStatusLabelResolution.Text = $"{videoResolution.Width}x{videoResolution.Height}";
-        server?.UpdateResolution(videoResolution);
+        server?.UpdateResolution(new WindowStreamer.Image.Size(videoResolution.Width, videoResolution.Height));
     }
 
     private void WindowCapture_FormClosed(object sender, FormClosedEventArgs e)
@@ -242,7 +240,7 @@ public partial class WindowCapture : Form
 
     private void aboutToolStripMenuItem_Click(object sender, EventArgs e)
     {
-        new CommonApp.AboutBoxMain().ShowDialog();
+        new AboutBoxMain().ShowDialog();
     }
 
     private void helpToolStripMenuItem_Click(object sender, EventArgs e)

--- a/WindowStreamer.Client/WindowStreamer.Client.csproj
+++ b/WindowStreamer.Client/WindowStreamer.Client.csproj
@@ -12,7 +12,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Drawing.Common" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/WindowStreamer.Client/WindowStreamer.Client.csproj
+++ b/WindowStreamer.Client/WindowStreamer.Client.csproj
@@ -16,6 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\WindowStreamer.Image\WindowStreamer.Image.csproj" />
     <ProjectReference Include="..\WindowStreamer.Protocol\WindowStreamer.Protocol.csproj" />
   </ItemGroup>
 

--- a/WindowStreamer.Image.Windows/NativeImage.cs
+++ b/WindowStreamer.Image.Windows/NativeImage.cs
@@ -1,0 +1,59 @@
+﻿using System.Drawing.Imaging;
+using System.Drawing;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+
+namespace WindowStreamer.Image.Windows
+{
+    [SupportedOSPlatform("windows")]
+    public class NativeImage : IImage
+    {
+        public NativeImage(Bitmap bitmap)
+        {
+            Bitmap = bitmap;
+        }
+
+        /// <summary>
+        /// Instantiates a new underlying Bitmap with the imagedata.
+        /// </summary>
+        /// <param name="imageData">24-bit RGB pixel data.</param>
+        /// <param name="size">The dimensions of the image.</param>
+        public NativeImage(byte[] imageData, int width, int height)
+        {
+            Bitmap = new Bitmap(width, height);
+
+            BitmapData bmpData = Bitmap.LockBits(new Rectangle(0, 0, Bitmap.Width, Bitmap.Height), ImageLockMode.WriteOnly, PixelFormat.Format24bppRgb);
+
+            IntPtr imageDataPtr = bmpData.Scan0;
+
+            Marshal.Copy(imageData, 0, imageDataPtr, imageData.Length);
+            Bitmap.UnlockBits(bmpData);
+        }
+
+        public Size Size => new Size(Bitmap.Width, Bitmap.Height);
+
+        public Bitmap Bitmap { get; private set; }
+
+        public static implicit operator Bitmap(NativeImage img) => img.Bitmap;
+        public static implicit operator NativeImage(Bitmap img) => new NativeImage(img);
+
+        public byte[] ToBytes() => ConvertBitmapToRawPixel24bpp(Bitmap);
+
+        static byte[] ConvertBitmapToRawPixel24bpp(Bitmap bmp)
+        {
+            BitmapData bmpData = bmp.LockBits(
+                new Rectangle(0, 0, bmp.Width, bmp.Height),
+                ImageLockMode.ReadOnly,
+                PixelFormat.Format24bppRgb);
+
+            IntPtr imageDataPtr = bmpData.Scan0;
+            int byteCount = Math.Abs(bmpData.Stride) * bmp.Height;
+            byte[] imageDump = new byte[byteCount];
+
+            Marshal.Copy(imageDataPtr, imageDump, 0, byteCount);
+            bmp.UnlockBits(bmpData);
+
+            return imageDump;
+        }
+    }
+}

--- a/WindowStreamer.Image.Windows/NativeImageFactory.cs
+++ b/WindowStreamer.Image.Windows/NativeImageFactory.cs
@@ -1,0 +1,10 @@
+﻿using System.Runtime.Versioning;
+
+namespace WindowStreamer.Image.Windows
+{
+    [SupportedOSPlatform("windows")]
+    public class NativeImageFactory : IImageFactory
+    {
+        public IImage CreateImage(byte[] imageData, Size size) => new NativeImage(imageData, size.Width, size.Height);
+    }
+}

--- a/WindowStreamer.Image.Windows/WindowStreamer.Image.Windows.csproj
+++ b/WindowStreamer.Image.Windows/WindowStreamer.Image.Windows.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Drawing.Common" Version="7.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\WindowStreamer.Image\WindowStreamer.Image.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/WindowStreamer.Image/IImage.cs
+++ b/WindowStreamer.Image/IImage.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace WindowStreamer.Image
+{
+    // TODO
+    // - Size type
+    // - 
+
+    /// <summary>
+    /// Represents a digital image.
+    /// </summary>
+    public interface IImage
+    {
+        /// <summary>
+        /// Gets a value indicating the size of the image.
+        /// </summary>
+        Size Size { get; }
+
+        /// <summary>
+        /// Returns 24-bit RGB pixel values in a single array.
+        /// </summary>
+        /// <returns>24-bit RGB image.</returns>
+        byte[] ToBytes();
+    }
+}

--- a/WindowStreamer.Image/IImageFactory.cs
+++ b/WindowStreamer.Image/IImageFactory.cs
@@ -1,5 +1,8 @@
 ﻿namespace WindowStreamer.Image
 {
+    /// <summary>
+    /// Produces images by image data.
+    /// </summary>
     public interface IImageFactory
     {
         /// <summary>

--- a/WindowStreamer.Image/IImageFactory.cs
+++ b/WindowStreamer.Image/IImageFactory.cs
@@ -1,0 +1,13 @@
+﻿namespace WindowStreamer.Image
+{
+    public interface IImageFactory
+    {
+        /// <summary>
+        /// Create an image by image data and dimensions.
+        /// </summary>
+        /// <param name="imageData">24-bit RGB pixel data.</param>
+        /// <param name="dimensions">The dimensions of the image.</param>
+        /// <returns></returns>
+        IImage CreateImage(byte[] imageData, Size dimensions);
+    }
+}

--- a/WindowStreamer.Image/Point.cs
+++ b/WindowStreamer.Image/Point.cs
@@ -1,0 +1,14 @@
+﻿namespace WindowStreamer.Image
+{
+    public readonly struct Point
+    {
+        public readonly int X;
+        public readonly int Y;
+
+        public Point(int x, int y)
+        {
+            X = x;
+            Y = y;
+        }
+    }
+}

--- a/WindowStreamer.Image/Size.cs
+++ b/WindowStreamer.Image/Size.cs
@@ -1,0 +1,14 @@
+﻿namespace WindowStreamer.Image
+{
+    public readonly struct Size
+    {
+        public readonly int Width;
+        public readonly int Height;
+
+        public Size(int width, int height)
+        {
+            Width = width;
+            Height = height;
+        }
+    }
+}

--- a/WindowStreamer.Image/WindowStreamer.Image.csproj
+++ b/WindowStreamer.Image/WindowStreamer.Image.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/WindowStreamer.Server/ConnectedClient.cs
+++ b/WindowStreamer.Server/ConnectedClient.cs
@@ -1,8 +1,8 @@
-﻿using System.Drawing;
-using System.Net;
+﻿using System.Net;
 using System.Net.Sockets;
 using Google.Protobuf;
 using Serilog;
+using WindowStreamer.Image;
 using WindowStreamer.Protocol;
 
 namespace WindowStreamer.Server;

--- a/WindowStreamer.Server/IGetCaptureArea.cs
+++ b/WindowStreamer.Server/IGetCaptureArea.cs
@@ -1,4 +1,4 @@
-﻿using System.Drawing;
+﻿using WindowStreamer.Image;
 
 namespace WindowStreamer.Server;
 

--- a/WindowStreamer.Server/IScreenshotQuery.cs
+++ b/WindowStreamer.Server/IScreenshotQuery.cs
@@ -1,9 +1,10 @@
-﻿using System.Drawing;
+﻿using WindowStreamer.Image;
 
 namespace WindowStreamer.Server;
 
 /// <summary>
 /// Recieves a query when ready to accept next image to be transmitted.
+/// TODO: Maybe rename to ScreenshotFactory.
 /// </summary>
 public interface IScreenshotQuery
 {
@@ -11,6 +12,7 @@ public interface IScreenshotQuery
     /// Grabs the next image to transmit.
     /// </summary>
     /// <returns>The screenshot to transmit.</returns>
+    /// <param name="location">The origin of the screenshot topleft corner.</param>
     /// <param name="captureRect">The area of the screen to capture.</param>
-    public Bitmap GetImage(Rectangle captureRect);
+    public IImage GetImage(Point location, Size captureRect);
 }

--- a/WindowStreamer.Server/WindowStreamer.Server.csproj
+++ b/WindowStreamer.Server/WindowStreamer.Server.csproj
@@ -12,7 +12,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Drawing.Common" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/WindowStreamer.Server/WindowStreamer.Server.csproj
+++ b/WindowStreamer.Server/WindowStreamer.Server.csproj
@@ -16,6 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\WindowStreamer.Image\WindowStreamer.Image.csproj" />
     <ProjectReference Include="..\WindowStreamer.Protocol\WindowStreamer.Protocol.csproj" />
   </ItemGroup>
 

--- a/WindowStreamer.sln
+++ b/WindowStreamer.sln
@@ -22,7 +22,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CommonApp", "CommonApp\Comm
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WindowStreamer.Server", "WindowStreamer.Server\WindowStreamer.Server.csproj", "{44F23EAC-D126-4623-B84A-F2A0C74ECBCE}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WindowStreamer.Image", "WindowStreamer.Image\WindowStreamer.Image.csproj", "{00A214A5-49DB-44CF-A576-F06B23DBA3E0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WindowStreamer.Image", "WindowStreamer.Image\WindowStreamer.Image.csproj", "{00A214A5-49DB-44CF-A576-F06B23DBA3E0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WindowStreamer.Image.Windows", "WindowStreamer.Image.Windows\WindowStreamer.Image.Windows.csproj", "{5A4777F6-2A80-41A0-B873-3E455679DAEA}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -58,6 +60,10 @@ Global
 		{00A214A5-49DB-44CF-A576-F06B23DBA3E0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{00A214A5-49DB-44CF-A576-F06B23DBA3E0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{00A214A5-49DB-44CF-A576-F06B23DBA3E0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5A4777F6-2A80-41A0-B873-3E455679DAEA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5A4777F6-2A80-41A0-B873-3E455679DAEA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5A4777F6-2A80-41A0-B873-3E455679DAEA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5A4777F6-2A80-41A0-B873-3E455679DAEA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/WindowStreamer.sln
+++ b/WindowStreamer.sln
@@ -22,6 +22,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CommonApp", "CommonApp\Comm
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WindowStreamer.Server", "WindowStreamer.Server\WindowStreamer.Server.csproj", "{44F23EAC-D126-4623-B84A-F2A0C74ECBCE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WindowStreamer.Image", "WindowStreamer.Image\WindowStreamer.Image.csproj", "{00A214A5-49DB-44CF-A576-F06B23DBA3E0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -52,6 +54,10 @@ Global
 		{44F23EAC-D126-4623-B84A-F2A0C74ECBCE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{44F23EAC-D126-4623-B84A-F2A0C74ECBCE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{44F23EAC-D126-4623-B84A-F2A0C74ECBCE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{00A214A5-49DB-44CF-A576-F06B23DBA3E0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{00A214A5-49DB-44CF-A576-F06B23DBA3E0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{00A214A5-49DB-44CF-A576-F06B23DBA3E0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{00A214A5-49DB-44CF-A576-F06B23DBA3E0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
The goal of this PR is to make all netcode (`WindowStreamer.*`) independent from `System.Drawing.Common`.

Resolves #37 